### PR TITLE
ffffm-ath9k-broken-wifi-workaround: also notify the router's log facility

### DIFF
--- a/ffffm/ffffm-ath9k-broken-wifi-workaround/files/lib/gluon/ath9k-broken-wifi-workaround/ath9k-broken-wifi-workaround.sh
+++ b/ffffm/ffffm-ath9k-broken-wifi-workaround/files/lib/gluon/ath9k-broken-wifi-workaround/ath9k-broken-wifi-workaround.sh
@@ -72,6 +72,7 @@ elif [ -f "$TMPFILE" ] && [ "$WIFICONNECTIONS" -eq 0 ] && [ "$PROBLEMS" -eq 1 ];
 	wifi
 	echo "$(date +%Y-%m-%d:%H:%M:%S)" > /tmp/log/wifi-last-restart-reasons-calib${CALIBERRORS}-queue${STOPPEDQUEUE}-tph${TXPATHHANG}
 	echo "there were connections before, but they vanished. restarted wifi and deleting tempfile."
+	logger "ath9k-broken-wifi-workaround: restart wifi - reasons-calib${CALIBERRORS}-queue${STOPPEDQUEUE}-tph${TXPATHHANG}"
 	rm $TMPFILE
 else
 	echo "everything seems to be ok."


### PR DESCRIPTION
if I am not mistaken: line 73 might need a double greater-than sign depending on if you want to build up a history of incidents in /tmp/log