### PR TITLE
ffffm-ath9k-broken-wifi-workaround: Fix support for batctl 2016.4

### DIFF
--- a/ffffm-ath9k-broken-wifi-workaround/files/lib/gluon/ath9k-broken-wifi-workaround/ath9k-broken-wifi-workaround.sh
+++ b/ffffm-ath9k-broken-wifi-workaround/files/lib/gluon/ath9k-broken-wifi-workaround/ath9k-broken-wifi-workaround.sh
@@ -182,7 +182,7 @@ fi
 
 # Try to ping the default gateway (needed mainly for wifi mesh only nodes)
 GWCONNECTION=0
-GATEWAY=$(batctl gwl | grep "^=>" | awk -F'[ ]' '{print $2}')
+GATEWAY=$(batctl gwl | grep -e "^=>" -e "^\*" | awk -F'[ ]' '{print $2}')
 if [ $GATEWAY ]; then
 	RANDOM=$(awk 'BEGIN { srand(); printf("%d\n",rand()*25) }')
 	sleep $RANDOM


### PR DESCRIPTION
The batman-adv/batctl 2016.4 release switched from debugfs to netlink as its primary way to retrieve information from the kernel module. This change had differently implications to the output format of batctl.

Also some cosmetic changes (like for example in the output for gwl) were done at the same time to make everything more consistent. This seemed to be the right point for doing these because many other things changed anyway.

Scripts which try to parse the output directly from batctl instead of using netlink have to be adjusted to continue to work. The parser for the selected gateway in this script has therefore to be modified to also search for the string "*" (common marker for selected entries in all outputs) instead of only for "=>".

This change is especially interesting for https://github.com/freifunk-gluon/gluon/pull/916