### PR TITLE
Allow NAT64 and only siteConfig.additional_prefix6

### DIFF
--- a/ffffm-ebtables-net-rules/files/lib/gluon/ebtables/110-ffffm-net-allow-ipv6-spaces
+++ b/ffffm-ebtables-net-rules/files/lib/gluon/ebtables/110-ffffm-net-allow-ipv6-spaces
@@ -13,12 +13,8 @@ end
 rule ('FFFFM_NET_ONLY -p IPv6 --ip6-src fe80::/10 -j RETURN')
 rule ('FFFFM_NET_ONLY -p IPv6 --ip6-dst ff00::/8 -j RETURN')
 rule ('FFFFM_NET_ONLY -p IPv6 --ip6-src ' .. siteConfig.prefix6 .. ' -j RETURN')
-rule ('FFFFM_NET_ONLY -p IPv6 --ip6-dst 2000::/3 -j RETURN')
 rule ('FFFFM_NET_ONLY -p IPv6 --ip6-dst 64:ff9b::/96 -j RETURN')
 rule ('FFFFM_NET_ONLY -p IPv6 --ip6-src 64:ff9b::/96 -j RETURN')
-
-rule ('FFFFM_NET_ONLY -p IPv6 --ip6-src 2a03:2260:1004::/48 -j RETURN')
-rule ('FFFFM_NET_ONLY -p IPv6 --ip6-src 2a06:8187:fb00::/40 -j RETURN')
 
 if siteConfig.additional_prefix6 then
   for prefix in list_iter(siteConfig.additional_prefix6) do


### PR DESCRIPTION
Allow ULAs and NAT64 well  known always.
Only allow src "additional_prefix6" from site.conf (https://github.com/freifunk-ffm/site-ffffm/pull/11)

This locks down the firmware again a bit (2000::/3 is not allowed by default anymore), now only pre configured prefixes are allowed for IPv6. => this may be unstable, testing is needed.