### PR TITLE
respondd-airtime: do not include invalid values in json structure

### DIFF
--- a/ffffm-additional-wifi-json-info/src/airtime.c
+++ b/ffffm-additional-wifi-json-info/src/airtime.c
@@ -15,15 +15,15 @@ static const char const *wifi_24_dev = "client0";
 static const char const *wifi_50_dev = "client1";
 
 struct airtime_result {
-        uint32_t frequency;
-        uint64_t active_time;
-        uint64_t busy_time;
+	uint32_t frequency;
+	uint64_t active_time;
+	uint64_t busy_time;
 };
 
 static int survey_airtime_handler(struct nl_msg *msg, void *arg)
 {
 	struct genlmsghdr *gnlh;
-        struct airtime_result *result;
+	struct airtime_result *result;
 
 	struct nlattr *tb[NL80211_ATTR_MAX + 1];
 	struct nlattr *sinfo[NL80211_SURVEY_INFO_MAX + 1];
@@ -31,110 +31,110 @@ static int survey_airtime_handler(struct nl_msg *msg, void *arg)
 		[NL80211_SURVEY_INFO_FREQUENCY] = { .type = NLA_U32 },
 	};
 
-        result = (struct airtime_result *) arg;
+	result = (struct airtime_result *) arg;
 
-        /* another callback was already successful */
-        if (result->frequency)
-                return NL_SKIP;
+	/* another callback was already successful */
+	if (result->frequency)
+		return NL_SKIP;
 
 	gnlh = nlmsg_data(nlmsg_hdr(msg));
-        if (!gnlh)
-                goto error;
+	if (!gnlh)
+		goto error;
 
 	nla_parse(tb, NL80211_ATTR_MAX, genlmsg_attrdata(gnlh, 0),
-		  genlmsg_attrlen(gnlh, 0), NULL);
+			genlmsg_attrlen(gnlh, 0), NULL);
 
 	if (!tb[NL80211_ATTR_SURVEY_INFO])
-                goto abort;
+		goto abort;
 
 	if (nla_parse_nested(sinfo, NL80211_SURVEY_INFO_MAX,
-			     tb[NL80211_ATTR_SURVEY_INFO],
-			     survey_policy))
-                goto abort;
+				tb[NL80211_ATTR_SURVEY_INFO],
+				survey_policy))
+		goto abort;
 
 	if (!sinfo[NL80211_SURVEY_INFO_CHANNEL_TIME]) 
-                goto abort;
+		goto abort;
 	if (!sinfo[NL80211_SURVEY_INFO_CHANNEL_TIME_BUSY])
-                goto abort;
+		goto abort;
 	if (!sinfo[NL80211_SURVEY_INFO_FREQUENCY])
-                goto abort;
+		goto abort;
 
-        result->frequency = (uint32_t)nla_get_u32(sinfo[NL80211_SURVEY_INFO_FREQUENCY]),
-        result->active_time = (uint64_t)nla_get_u64(sinfo[NL80211_SURVEY_INFO_CHANNEL_TIME]);
-        result->busy_time = (uint64_t)nla_get_u64(sinfo[NL80211_SURVEY_INFO_CHANNEL_TIME_BUSY]);
+	result->frequency = (uint32_t)nla_get_u32(sinfo[NL80211_SURVEY_INFO_FREQUENCY]),
+		result->active_time = (uint64_t)nla_get_u64(sinfo[NL80211_SURVEY_INFO_CHANNEL_TIME]);
+	result->busy_time = (uint64_t)nla_get_u64(sinfo[NL80211_SURVEY_INFO_CHANNEL_TIME_BUSY]);
 
 error:
 abort:
-        return NL_SKIP;
+	return NL_SKIP;
 }
 
 static double get_airtime_for_interface(const char *interface) {
-        double ret = FFFFM_INVALID_AIRTIME;
-        int ctrl, ifx, flags;
-        struct nl_sock *sk = NULL;
-        struct nl_msg *msg = NULL;
-        enum nl80211_commands cmd;
-        struct airtime_result *result = NULL;
+	double ret = FFFFM_INVALID_AIRTIME;
+	int ctrl, ifx, flags;
+	struct nl_sock *sk = NULL;
+	struct nl_msg *msg = NULL;
+	enum nl80211_commands cmd;
+	struct airtime_result *result = NULL;
 
 #define CHECK(x) { if (!(x)) { printf("error on line %d\n",  __LINE__); goto error; } }
 
-        CHECK(sk = nl_socket_alloc());
-        CHECK(genl_connect(sk) >= 0);
+	CHECK(sk = nl_socket_alloc());
+	CHECK(genl_connect(sk) >= 0);
 
-        CHECK(ctrl = genl_ctrl_resolve(sk, NL80211_GENL_NAME));
-        CHECK(result = calloc(1, sizeof(*result)));
-        CHECK(nl_socket_modify_cb(
-                sk, NL_CB_VALID, NL_CB_CUSTOM, survey_airtime_handler, result) == 0);
-        CHECK(msg = nlmsg_alloc());
+	CHECK(ctrl = genl_ctrl_resolve(sk, NL80211_GENL_NAME));
+	CHECK(result = calloc(1, sizeof(*result)));
+	CHECK(nl_socket_modify_cb(
+				sk, NL_CB_VALID, NL_CB_CUSTOM, survey_airtime_handler, result) == 0);
+	CHECK(msg = nlmsg_alloc());
 
-        /* device does not exist */
-        if (!(ifx = if_nametoindex(interface)))
-                goto error;
+	/* device does not exist */
+	if (!(ifx = if_nametoindex(interface)))
+		goto error;
 
-        cmd = NL80211_CMD_GET_SURVEY;
-        flags = 0;
-        flags |= NLM_F_DUMP;
+	cmd = NL80211_CMD_GET_SURVEY;
+	flags = 0;
+	flags |= NLM_F_DUMP;
 
-        /* TODO: check return? */
-        genlmsg_put(msg, 0, 0, ctrl, 0, flags, cmd, 0);
+	/* TODO: check return? */
+	genlmsg_put(msg, 0, 0, ctrl, 0, flags, cmd, 0);
 
-        NLA_PUT_U32(msg, NL80211_ATTR_IFINDEX, ifx);
+	NLA_PUT_U32(msg, NL80211_ATTR_IFINDEX, ifx);
 
-        CHECK(nl_send_auto_complete(sk, msg) >= 0);
-        CHECK(nl_recvmsgs_default(sk) >= 0);
+	CHECK(nl_send_auto_complete(sk, msg) >= 0);
+	CHECK(nl_recvmsgs_default(sk) >= 0);
 
 	ret = ((double) result->busy_time) / result->active_time;
 
 #undef CHECK
 
 out:
-    if (msg)
-            nlmsg_free(msg);
-    msg = NULL;
+	if (msg)
+		nlmsg_free(msg);
+	msg = NULL;
 
-    if (sk)
-            nl_socket_free(sk);
-    sk = NULL;
+	if (sk)
+		nl_socket_free(sk);
+	sk = NULL;
 
-    if (result)
-            free(result);
-    result = NULL;
+	if (result)
+		free(result);
+	result = NULL;
 
-    return ret;
+	return ret;
 
 nla_put_failure:
 error:
-    ret = FFFFM_INVALID_AIRTIME;
-    goto out;
+	ret = FFFFM_INVALID_AIRTIME;
+	goto out;
 }
 
 struct ffffm_airtime *ffffm_get_airtime(void) {
 	struct ffffm_airtime *ret = calloc(1, sizeof(*ret));
-        if (!ret)
-                return NULL;
+	if (!ret)
+		return NULL;
 
-        ret->a24 = get_airtime_for_interface(wifi_24_dev);
-        ret->a50 = get_airtime_for_interface(wifi_50_dev);
-        
-        return ret;
+	ret->a24 = get_airtime_for_interface(wifi_24_dev);
+	ret->a50 = get_airtime_for_interface(wifi_50_dev);
+
+	return ret;
 }

--- a/ffffm-additional-wifi-json-info/src/respondd-wireless.c
+++ b/ffffm-additional-wifi-json-info/src/respondd-wireless.c
@@ -26,13 +26,13 @@ static struct json_object *respondd_provider_statistics(void) {
 
         struct json_object *v;
 
-	if (a->a24 != FFFFM_INVALID_AIRTIME) {
+	if (a->a24 >= 0 ) {
 		v = json_object_new_double(a->a24);
 		if (!v)
 			goto end;
 		json_object_object_add(wireless, "airtime2", v);
 	}
-	if (a->a50 != FFFFM_INVALID_AIRTIME) {
+	if (a->a50 >= 0 ) {
 		v = json_object_new_double(a->a50);
 		if (!v)
 			goto end;


### PR DESCRIPTION
this is an attempt to fix the issue of respondd providing invalid json data which in turn causes yannic to barf.

raising this PR even before test so we have a reminder to get this done.