### PR TITLE
REAMDE.md: Allgemeiner Lizenzhinweis (MIT) hinzu gefügt

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2019 Freifunk Frankfurt 
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) 2019 Freifunk Frankfurt 
+Copyright (c) 2019 Freifunk Frankfurt am Main
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/README.md
+++ b/README.md
@@ -1,6 +1,8 @@
 This repository holds all packages from Freifunk Frankfurt that are meant to be
 used with the gluon firmware.
 
+The [MIT license](https://raw.githubusercontent.com/angular/angular.js/master/LICENSE) applies unless otherwise stated. 
+
 ---
 
 *** USE OF BRANCHES ***

--- a/README.md
+++ b/README.md
@@ -1,7 +1,8 @@
 This repository holds all packages from Freifunk Frankfurt that are meant to be
 used with the gluon firmware.
 
-The [MIT license](https://raw.githubusercontent.com/angular/angular.js/master/LICENSE) applies unless otherwise stated. 
+The [MIT license](https://raw.githubusercontent.com/freifunk-ffm/packages/master/LICENSE) applies unless otherwise stated. 
+                  
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 This repository holds all packages from Freifunk Frankfurt that are meant to be
 used with the gluon firmware.
 
-The [MIT license](https://raw.githubusercontent.com/freifunk-ffm/packages/master/LICENSE) applies unless otherwise stated. 
+The [MIT license](LICENSE) applies unless otherwise stated. 
                   
 
 ---


### PR DESCRIPTION
Wenn ich das richtig sehe, dann haben nur @christf und ich hier die Finger im Spiel.
Und ich bin, glaube ich jedenfalls, der einzige, der u.a. auf Forks zurückgegriffen hat (vorauf dann aber auch in den entsprechenden README.md hingewiesen wird).
Falls es Frankfurter Einwände geben sollte, dann bitte entsprechend melden.
