### PR TITLE
ffffm-ath9k-broken-wifi-workaround: Avoid overlong sleeps

### DIFF
--- a/ffffm-ath9k-broken-wifi-workaround/files/lib/gluon/ath9k-broken-wifi-workaround/ath9k-broken-wifi-workaround.sh
+++ b/ffffm-ath9k-broken-wifi-workaround/files/lib/gluon/ath9k-broken-wifi-workaround/ath9k-broken-wifi-workaround.sh
@@ -199,8 +199,8 @@ done
 GWCONNECTION=0
 GATEWAY=$(batctl gwl | grep -e "^=>" -e "^\*" | awk -F'[ ]' '{print $2}')
 if [ $GATEWAY ]; then
-	RANDOM=$(awk 'BEGIN { srand(); printf("%d\n",rand()*25) }')
-	sleep $RANDOM
+	RANDSLEEP=$(awk 'BEGIN { srand(); printf("%d\n",rand()*25) }')
+	sleep $RANDSLEEP
 	batctl ping -c 5 $GATEWAY > /dev/null 2>&1
 	if [ $? -eq 0 ]; then
 		GWCONNECTION=1


### PR DESCRIPTION
The ath9k workaround is using a sleep before starting a batctl ping. The time for the sleep is calculated using awk and should be between 0-24 seconds. The duration is then tried to be stored in `$RANDOM`.

Unfortunately, `$RANDOM` is a special variable in bash/ksh/... which always returns a "different" random value when read. This behavior is also enabled in ash when `CONFIG_ASH_RANDOM_SUPPORT` is enabled - which is the case since OpenWrt commit `8f427f1a058d ("busybox: turn on
BUSYBOX_DEFAULT_ASH_RANDOM_SUPPORT for having $RANDOM")`.

The script is therefore creating sleep durations of 0-32767s since OpenWrt 23.05. As result, the script either:
    
* for versions without the LOCK: the number of sleep processes (and related ash processes) increase steadily and after some time use up all memory on the system.
* for versions with the LOCK: the script will not do anything (besides logging "Another instance is still running, aborting.") for a long time


Just rename the variable to avoid this problem.